### PR TITLE
Allow passing config to run

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ async function runPuppeteer(baseUrl, routes, dir) {
   return;
 } 
 
-async function run() {
-  const options = await readOptionsFromFile();
+async function run(config) {
+  const options = config || await readOptionsFromFile();
   const staticServerURL = await runStaticServer(options.port || 3000, options.routes || [], options.buildDirectory || './build');
 
   if (!staticServerURL) return 0;


### PR DESCRIPTION
Hi, I would like to use your tool programmatically, because I have multiple builds to handle. I need to pass a config object related to each build to `run` for that