### PR TITLE
Allow passing config to run

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,8 +113,8 @@ async function runPuppeteer(baseUrl, routes, dir, engine) {
   return;
 }
 
-async function run() {
-  const options = await readOptionsFromFile();
+async function run(config) {
+  const options = config || await readOptionsFromFile();
   const staticServerURL = await runStaticServer(options.port, options.routes, options.buildDirectory);
 
   if (!staticServerURL) return 0;


### PR DESCRIPTION
Hi, I would like to use your tool programmatically, because I have multiple builds to handle. I need to pass a config object related to each build to `run` for that