### PR TITLE
Added outputDirectory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ That's it. After accomplishing all the steps above, run you build command and yo
 | routes(Required) | Array | - | An array of routes you want to parse and prerender into static html|
 | port | Number | 3000 | port where prerendering server will be starting |
 | buildDirectory | String | './build' | a relative path to your build folder
-|engine | Object | {} | params for Puppeteer engine, list of available params described below
+| outputDirectory | String | './build' | a relative path to the folder for the output files
+| engine | Object | {} | params for Puppeteer engine, list of available params described below
 
 
 ### Engine options:

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ async function run(config) {
 
   if (!staticServerURL) return 0;
 
-  await runPuppeteer(staticServerURL, options.routes, options.buildDirectory, options.engine);
+  await runPuppeteer(staticServerURL, options.routes, options.outputDirectory, options.engine);
   console.log('Finish react-spa-prerender tasks!');
   process.exit();
 }

--- a/utils/normalizeRspOptions.js
+++ b/utils/normalizeRspOptions.js
@@ -13,6 +13,7 @@ module.exports = function (options) {
     routes: options.routes || [],
     port: options.port || 3000,
     buildDirectory: options.buildDirectory || './build',
+    outputDirectory: options.outputDirectory || options.buildDirectory || './build',
     engine
   };
 };


### PR DESCRIPTION
Hi,

I added an `outputDirectory` option to be able to render the pages into a separate directory.

This can be useful when serving the content in a dynamic way. In my case, I am serving my site from Go, with most files embedded in the executable for fast access, but I do not want all the static HTML files in the build, but in a separate directory.

This is described in my medium post at https://medium.com/@siggi.oskarsson/running-react-in-a-go-api-server-1ad8d40c2411

Hope it is useful.