### PR TITLE
feat(trail): slash support

### DIFF
--- a/utils/getValidatedFileName.js
+++ b/utils/getValidatedFileName.js
@@ -1,11 +1,16 @@
 /**
  * Set .html as default file extension if not exists
  * @param {string} route
- * @returns {string} 
+ * @returns {string}
  */
 module.exports = function(route) {
   const fileName = route === '/' ? '/index' : route;
   const withExtension = !!fileName.match(/(.htm$|.html$|.php$)/i);
 
-  return withExtension ? fileName : `${fileName}.html`;
+  if (withExtension) {
+    return fileName;
+  }
+
+  // Handle trailing slashes by appending index.html
+  return fileName.endsWith('/') ? `${fileName}index.html` : `${fileName}.html`;
 }


### PR DESCRIPTION
### Fix: Generate `index.html` for routes with trailing slashes

**Problem**  
Routes ending with a trailing slash (e.g. `/about/`, `/work/project/`) currently generate invalid paths like `dist/about/.html` instead of `dist/about/index.html`, breaking standard web server behavior.

**Root Cause**  
`getValidatedFileName.js` always appends `.html` to routes without extensions, ignoring trailing slashes.

**Solution**  
Update logic to detect trailing slashes and append `index.html` instead of `.html`:
```js
return fileName.endsWith('/')
  ? `${fileName}index.html`
  : `${fileName}.html`;
```

**Examples**
| Route | Before | After |
|--------|---------|--------|
| `/about/` | `dist/about/.html` ❌ | `dist/about/index.html` ✅ |
| `/work/project/` | `dist/work/project/.html` ❌ | `dist/work/project/index.html` ✅ |

**Backward Compatibility**  
- `/page` → `/page.html` (unchanged)  
- `/` → `/index.html` (unchanged)  
- `/page.html` → `/page.html` (unchanged)
